### PR TITLE
[Needs help] Migrate to newer LLVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.6
+      - llvm-toolchain-precise-3.8
     packages:
-      - llvm-3.6
-      - llvm-3.6-dev
-      - clang-3.6
+      - llvm-3.8
+      - llvm-3.8-dev
+      - clang-3.8
       - libedit-dev
+
+env:
+  - ASAN_OPTIONS="detect_leaks=0"
 
 script:
   - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN \
   apt-get update && \
   apt-get upgrade -y && \
   apt-get install zlib1g-dev -y && \
-  apt-get install clang-3.6 clang-3.6-doc libclang-common-3.6-dev libclang-3.6-dev libclang1-3.6 libclang1-3.6-dbg libllvm3.6v5 libllvm3.6-dbg lldb-3.6 llvm-3.6 llvm-3.6-dev llvm-3.6-doc llvm-3.6-examples llvm-3.6-runtime clang-modernize-3.6 clang-format-3.6 python-clang-3.6 lldb-3.6-dev opt libedit-dev build-essential make -y; \
-  ln -s /usr/bin/clang-3.6 /usr/bin/clang; \
-  ln -s /usr/bin/clang++-3.6 /usr/bin/clang++;
+  apt-get install clang-3.8 clang-3.8-doc libclang-common-3.8-dev libclang-3.8-dev libclang1-3.8 libclang1-3.8-dbg libllvm3.8v5 libllvm3.8-dbg lldb-3.8 llvm-3.8 llvm-3.8-dev llvm-3.8-doc llvm-3.8-examples llvm-3.8-runtime clang-modernize-3.8 clang-format-3.8 python-clang-3.8 lldb-3.8-dev opt libedit-dev build-essential make -y; \
+  ln -s /usr/bin/clang-3.8 /usr/bin/clang; \
+  ln -s /usr/bin/clang++-3.8 /usr/bin/clang++;
 
 ADD . /opt/qcc
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX := clang++-3.8
 LLVM_CONFIG := llvm-config-3.8
 CXXFLAGS := -fsanitize=address -MMD -MP $(shell $(LLVM_CONFIG) --cxxflags)
-LIBS := -lm $(shell $(LLVM_CONFIG) --system-libs --ldflags --libs all)
+LIBS := $(shell $(LLVM_CONFIG) --system-libs --ldflags --libs all)
 
 PROG := qcc
 SRCS := $(wildcard src/*.cpp)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CXX := clang++-3.6
-LLVM_CONFIG := llvm-config-3.6
-CXXFLAGS := -O3 -std=c++11 -MMD -MP $(shell $(LLVM_CONFIG) --cxxflags)
+CXX := clang++-3.8
+LLVM_CONFIG := llvm-config-3.8
+CXXFLAGS := -fsanitize=address -MMD -MP $(shell $(LLVM_CONFIG) --cxxflags)
 LIBS := -lm $(shell $(LLVM_CONFIG) --system-libs --ldflags --libs all)
 
 PROG := qcc

--- a/qcc.sh
+++ b/qcc.sh
@@ -1,5 +1,5 @@
 ./qcc $1 -emit-ir
-opt-3.6 -std-link-opts a.bc -o a.bc
-llc-3.6 a.bc -O3
-clang a.s -O3 -lm
+opt-3.8 -std-link-opts a.bc -o a.bc
+llc-3.8 a.bc -O3
+clang-3.8 a.s -O3 -lm
 rm a.s a.bc

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -537,7 +537,7 @@ llvm::Value *Codegen::get_value_struct(llvm::Value *parent, struct_t *sinfo, std
     if(m == elem_name) break;
     member_count++;
   }
-  return builder.CreateStructGEP(/*parent->getType()->getPointerElementType(), */ parent, member_count);
+  return builder.CreateStructGEP(parent->getType()->getPointerElementType(), parent, member_count);
 }
 llvm::Value *Codegen::get_value_union(llvm::Value *parent, union_t *uinfo, std::string elem_name) {
   llvm::Type *member_type = nullptr;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -212,11 +212,13 @@ llvm::Value *Codegen::statement(FunctionCallAST *st) {
         params <= i ? statement(a) : // varaible argument                                    
         type_cast(statement(a), f->getType()->getPointerElementType()->getFunctionParamType(i++))
         );
-  } 
-  auto callee = f;
-  auto ret = builder.CreateCall(callee, caller_args);
-  if(!callee->getReturnType()->isVoidTy())
-    return ret;
+  }
+
+  if(f == nullptr) error("f->getFunctionType() is nullptr");
+  if(f->getFunctionType() == nullptr) error("f->getFunctionType() is nullptr");
+
+  if(!f->getReturnType()->isVoidTy())
+    return builder.CreateCall(f, caller_args);
   return nullptr;
 }
 

--- a/src/qcc.cpp
+++ b/src/qcc.cpp
@@ -76,7 +76,7 @@ void QCC::show_usage() {
 void error(const char *errs, ...) {
   va_list args;
   va_start(args, errs);
-    vprintf(errs, args); puts("");
+    vfprintf(stderr,errs, args); fputs("\n",stderr);
   va_end(args);
-  exit(0);
+  exit(1);
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,3 +1,4 @@
+echo $1
 ./qcc $1.c -o $1.bc > /dev/null
-llc-3.6 $1.bc -o $1.s
-clang $1.s -D"TEST_NAME=\"$1\"" test/main.c -o $1.bin
+llc-3.8 $1.bc -o $1.s
+clang-3.8 $1.s -D"TEST_NAME=\"$1\"" test/main.c -o $1.bin


### PR DESCRIPTION
The changes of LLVM which needs work:
### LLVM 3.6
- [x] **(Merged into `develop`)** `llvm/ExecutionEngine/JIT.h` doesn't exist anymore.
- [x] **(Merged into `develop`)** The second argument of constructor for `llvm::raw_fd_ostream` is now `std::error_code` instead of `std::string` (Will need incompatible change with LLVM 3.5)

### LLVM 3.7
- [x] **(Merged into `develop`)** `llvm/PassManager.h` doesn't exist anymore.
- [x] **(Merged into `develop`)** `llvm::IRBuilder::CreateStructGEP` now require additional argument `Type* Ty`. (Will need incompatible change with LLVM 3.5)

### LLVM 3.8
- [x] **(Merged into `develop`)** Type `ilist_iterator<T>` cannot be implicitly converted to type `T*` anymore. (The conversion function is now with `explicit` specifier)

### LLVM 3.9
- [ ] `llvm::getGlobalContext()` doesn't exist anymore. ("*There is no longer a “global context” available in LLVM*" according to [the release note](http://releases.llvm.org/3.9.1/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release))