### PR TITLE
Make compatible with LLVM 3.9

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,7 +1,7 @@
 #include "codegen.hpp"
 #include "parse.hpp"
 
-llvm::LLVMContext &context(llvm::getGlobalContext());
+llvm::LLVMContext context;
 llvm::IRBuilder<> builder(context);
 llvm::Module *mod;
 llvm::DataLayout *data_layout;

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -5,7 +5,7 @@
 #include "func.hpp"
 #include "struct.hpp"
 
-extern llvm::LLVMContext &context;
+extern llvm::LLVMContext context;
 extern llvm::IRBuilder<> builder;
 extern llvm::Module *mod;
 extern llvm::DataLayout *data_layout;


### PR DESCRIPTION
`llvm::getGlobalContext()` doesn't exist in LLVM 3.9 anymore.

Before LLVM 3.9 `llvm::getGlobalContext()` is implemented in this way.

```cpp
LLVMContext& llvm::getGlobalContext() {
  return *GlobalContext;
}
```

`GlobalContext` is a `static` global variable.
It is default-constructed.

Since `context` is the only instance of `LLVMContext` in your project, it's safe to change type of `context` from `LLVMContext&` to `LLVMContext`.