### PR TITLE
Add NO_ANSI_KEYWORDS

### DIFF
--- a/include/qcc.h
+++ b/include/qcc.h
@@ -32,6 +32,7 @@
 #define __x86_64 1
 #define __x86_64__ 1
 #define linux 1
+#define NO_ANSI_KEYWORDS 1
 
 #define __alignof__ alignof
 #define __const__ const


### PR DESCRIPTION
Without `NO_ANSI_KEYWORDS`, some keywords (`const`, `inline`, `signed`, and `volatile`) will be deleted on macOS and FreeBSD (and probably on any *BSD)